### PR TITLE
removed config.kit.target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules
 .env
 .env.local
 .svelte-kit
+.pnpm*
+pnpm*

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -18,9 +18,6 @@ export default {
 		// specifying a different adapter
 		adapter: node(),
 
-		// hydrate the <div id="svelte"> element in src/app.html
-		target: '#svelte',
-
 		// vite: {
 		// 	ssr: {
 		// 		noExternal: Object.keys(pkg.dependencies || {})


### PR DESCRIPTION
`config.kit.target` is removed in recent versions of SvelteKit.
So It is not needed and throws an error while running the project.
This PR removes `config.kit.target` from `svelte.config.js`