### PR TITLE
Reset supbase auth if cookie is not set

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -18,6 +18,8 @@ export async function handle({ event, resolve }: { event: RequestEvent, resolve:
         event.locals.user = user
     } else {
         event.locals.user = RESP_USER_GUEST
+        // If token is not present, reset supabase auth
+        await auth.setAuth(null)
     }
 
 	let response = await resolve(event);


### PR DESCRIPTION
If the auth is not reset, user for supabase auth is set to an authenticated user even for a non authenticated user if the request is after a successful signin of a user.